### PR TITLE
feat: add fuzzy search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,154 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { fuzzyScore, searchFile, fileExists, getFileDetails, listDataFiles } from './index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_DIR = path.join(__dirname, 'data');
+
+describe('fuzzyScore', () => {
+    it('returns 100 for an exact substring match', () => {
+        expect(fuzzyScore('abyssal_whip', 'whip')).toBe(100);
+    });
+
+    it('returns 100 for a full match', () => {
+        expect(fuzzyScore('dragon_sword', 'dragon_sword')).toBe(100);
+    });
+
+    it('returns 75 when all space/underscore-split tokens are present', () => {
+        expect(fuzzyScore('dragon_sword_of_doom', 'dragon sword')).toBe(75);
+    });
+
+    it('returns a positive subsequence score for fuzzy match (typo-like)', () => {
+        const score = fuzzyScore('abyssal_whip', 'abssl');
+        expect(score).toBeGreaterThan(0);
+        expect(score).toBeLessThan(100);
+    });
+
+    it('returns 0 when not all pattern chars are present in sequence', () => {
+        expect(fuzzyScore('dragon', 'xyz')).toBe(0);
+    });
+
+    it('is case-insensitive', () => {
+        expect(fuzzyScore('Dragon_Sword', 'dragon')).toBe(100);
+    });
+
+    it('exact match scores higher than subsequence match', () => {
+        const exact = fuzzyScore('abyssal_whip', 'whip');
+        const subseq = fuzzyScore('abyssal_whip', 'awip');
+        expect(exact).toBeGreaterThan(subseq);
+    });
+});
+
+describe('searchFile (real data files)', () => {
+    const varptypesPath = path.join(DATA_DIR, 'varptypes.txt');
+    const objtypesPath = path.join(DATA_DIR, 'objtypes.txt');
+
+    it('finds exact matches in varptypes.txt', async () => {
+        const result = await searchFile(varptypesPath, 'cannon');
+        expect(result.results.length).toBeGreaterThan(0);
+        expect(result.results[0].line.toLowerCase()).toContain('cannon');
+    });
+
+    it('returns results with id, value, and formatted fields', async () => {
+        const result = await searchFile(varptypesPath, 'cannon');
+        const first = result.results[0];
+        expect(first).toHaveProperty('id');
+        expect(first).toHaveProperty('value');
+        expect(first).toHaveProperty('formatted');
+        expect(first.formatted).toContain('\t');
+    });
+
+    it('converts spaces to underscores before searching', async () => {
+        const withSpace = await searchFile(objtypesPath, 'mcannon ball');
+        const withUnderscore = await searchFile(objtypesPath, 'mcannonball');
+        expect(withSpace.pagination.totalResults).toBe(withUnderscore.pagination.totalResults);
+    });
+
+    it('returns correct pagination metadata', async () => {
+        const result = await searchFile(varptypesPath, 'quest', 1, 5);
+        expect(result.pagination.page).toBe(1);
+        expect(result.pagination.pageSize).toBe(5);
+        expect(result.results.length).toBeLessThanOrEqual(5);
+        if (result.pagination.totalResults > 5) {
+            expect(result.pagination.hasNextPage).toBe(true);
+        }
+    });
+
+    it('returns second page of results', async () => {
+        const page1 = await searchFile(varptypesPath, 'quest', 1, 3);
+        const page2 = await searchFile(varptypesPath, 'quest', 2, 3);
+        if (page1.pagination.totalPages >= 2) {
+            expect(page2.results[0].line).not.toBe(page1.results[0].line);
+            expect(page2.pagination.hasPreviousPage).toBe(true);
+        }
+    });
+
+    it('sorts results so exact matches come before fuzzy matches', async () => {
+        const result = await searchFile(objtypesPath, 'mcannonball');
+        const lines: string[] = result.results.map((r: any) => r.line as string);
+        const exactIndex = lines.findIndex(l => l.toLowerCase().includes('mcannonball'));
+        const fuzzyIndex = lines.findIndex(l => !l.toLowerCase().includes('mcannonball'));
+        if (exactIndex !== -1 && fuzzyIndex !== -1) {
+            expect(exactIndex).toBeLessThan(fuzzyIndex);
+        }
+    });
+
+    it('rejects with an error for a non-existent file', async () => {
+        await expect(searchFile('/nonexistent/path/file.txt', 'test')).rejects.toThrow('File not found');
+    });
+
+    it('returns empty results for a query with no matches', async () => {
+        const result = await searchFile(varptypesPath, 'zzz_no_match_xqq');
+        expect(result.results).toHaveLength(0);
+        expect(result.pagination.totalResults).toBe(0);
+    });
+});
+
+describe('fileExists', () => {
+    it('returns true for files that exist in the data directory', () => {
+        expect(fileExists('varptypes.txt')).toBe(true);
+        expect(fileExists('objtypes.txt')).toBe(true);
+        expect(fileExists('npctypes.txt')).toBe(true);
+    });
+
+    it('returns false for files that do not exist', () => {
+        expect(fileExists('nonexistent.txt')).toBe(false);
+    });
+});
+
+describe('getFileDetails', () => {
+    it('returns exists:true and metadata for a real file', () => {
+        const details = getFileDetails('varptypes.txt');
+        expect(details.exists).toBe(true);
+        expect(details.size).toBeGreaterThan(0);
+        expect(details.lineCount).toBeGreaterThan(0);
+        expect(details.created).toBeTruthy();
+        expect(details.lastModified).toBeTruthy();
+    });
+
+    it('returns exists:false for a missing file', () => {
+        const details = getFileDetails('nonexistent.txt');
+        expect(details.exists).toBe(false);
+    });
+});
+
+describe('listDataFiles', () => {
+    it('returns all data files when no filter is given', () => {
+        const files = listDataFiles();
+        expect(files.length).toBeGreaterThan(0);
+        expect(files).toContain('varptypes.txt');
+        expect(files).toContain('objtypes.txt');
+    });
+
+    it('filters by file extension', () => {
+        const txtFiles = listDataFiles('txt');
+        expect(txtFiles.every(f => f.endsWith('.txt'))).toBe(true);
+        expect(txtFiles.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty array when filter matches nothing', () => {
+        const result = listDataFiles('xyz');
+        expect(result).toEqual([]);
+    });
+});

--- a/index.ts
+++ b/index.ts
@@ -95,6 +95,38 @@ const server = new Server(
 );
 
 /**
+ * Score how well a line matches a search term.
+ * Returns 0 if no match, higher = better.
+ */
+export function fuzzyScore(text: string, pattern: string): number {
+    const t = text.toLowerCase();
+    const p = pattern.toLowerCase();
+
+    // Exact substring — best
+    if (t.includes(p)) return 100;
+
+    // All whitespace/underscore-split tokens present as substrings
+    const tokens = p.split(/[\s_]+/).filter(Boolean);
+    if (tokens.length > 1 && tokens.every(tok => t.includes(tok))) return 75;
+
+    // Character subsequence match (handles typos / partial queries)
+    let score = 0;
+    let pIdx = 0;
+    let consecutive = 0;
+    for (let i = 0; i < t.length && pIdx < p.length; i++) {
+        if (t[i] === p[pIdx]) {
+            score += 1 + consecutive;
+            consecutive++;
+            pIdx++;
+        } else {
+            consecutive = 0;
+        }
+    }
+    if (pIdx < p.length) return 0; // not all chars matched
+    return Math.min(50, Math.floor((score / p.length) * 20));
+}
+
+/**
  * Search through a file for matching lines
  * @param filePath Path to the file to search
  * @param searchTerm Term to search for
@@ -102,16 +134,15 @@ const server = new Server(
  * @param pageSize Number of results per page
  * @returns Object containing results and pagination info
  */
-async function searchFile(filePath: string, searchTerm: string, page: number = 1, pageSize: number = 10): Promise<any> {
-    //replace spaces with underscores
-    searchTerm = searchTerm.replace(" ", "_");
+export async function searchFile(filePath: string, searchTerm: string, page: number = 1, pageSize: number = 10): Promise<any> {
+    searchTerm = searchTerm.replace(/ /g, "_");
     return new Promise((resolve, reject) => {
         if (!fs.existsSync(filePath)) {
             reject(new Error(`File not found: ${filePath}`));
             return;
         }
 
-        const results: {line: string, lineNumber: number}[] = [];
+        const results: {line: string, lineNumber: number, score: number}[] = [];
         const fileStream = fs.createReadStream(filePath);
         const rl = readline.createInterface({
             input: fileStream,
@@ -122,12 +153,14 @@ async function searchFile(filePath: string, searchTerm: string, page: number = 1
         
         rl.on('line', (line) => {
             lineNumber++;
-            if (line.toLowerCase().includes(searchTerm.toLowerCase())) {
-                results.push({ line, lineNumber });
+            const score = fuzzyScore(line, searchTerm);
+            if (score > 0) {
+                results.push({ line, lineNumber, score });
             }
         });
 
         rl.on('close', () => {
+            results.sort((a, b) => b.score - a.score);
             const totalResults = results.length;
             const totalPages = Math.ceil(totalResults / pageSize);
             const startIndex = (page - 1) * pageSize;
@@ -135,7 +168,7 @@ async function searchFile(filePath: string, searchTerm: string, page: number = 1
             const paginatedResults = results.slice(startIndex, endIndex);
 
             // Process the results to extract key-value pairs if possible
-            const formattedResults = paginatedResults.map(result => {
+            const formattedResults = paginatedResults.map(({ score, ...result }) => {
                 // Try to format as key-value pair (common for ID data files)
                 const parts = result.line.split(/\s+/);
                 if (parts.length >= 2) {
@@ -175,7 +208,7 @@ async function searchFile(filePath: string, searchTerm: string, page: number = 1
  * @param filename The filename to check
  * @returns Boolean indicating if the file exists
  */
-function fileExists(filename: string): boolean {
+export function fileExists(filename: string): boolean {
     const filePath = path.join(DATA_DIR, filename);
     return fs.existsSync(filePath);
 }
@@ -185,7 +218,7 @@ function fileExists(filename: string): boolean {
  * @param filename The filename to get details for
  * @returns Object with file details
  */
-function getFileDetails(filename: string): any {
+export function getFileDetails(filename: string): any {
     try {
         const filePath = path.join(DATA_DIR, filename);
         if (!fs.existsSync(filePath)) {
@@ -228,7 +261,7 @@ function getFileLineCount(filePath: string): number {
  * @param fileType Optional filter for file type
  * @returns Array of file names
  */
-function listDataFiles(fileType?: string): string[] {
+export function listDataFiles(fileType?: string): string[] {
     try {
         const files = fs.readdirSync(DATA_DIR);
         
@@ -508,7 +541,9 @@ async function main() {
     }
 }
 
-main().catch((error) => {
-    console.error("Fatal error in main():", error);
-    process.exit(1);
-});
+if (!process.env.JEST_WORKER_ID) {
+    main().catch((error) => {
+        console.error("Fatal error in main():", error);
+        process.exit(1);
+    });
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,12 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: 'tsconfig.test.json' }],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/node": "^25.9.1",
         "copyfiles": "^2.4.1",
         "jest": "^29.7.0",
         "rimraf": "^6.0.1",
@@ -70,6 +71,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1079,12 +1081,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1215,6 +1218,7 @@
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
       "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1408,6 +1412,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2148,6 +2153,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2925,6 +2931,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5102,6 +5109,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5111,10 +5119,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -5465,6 +5474,7 @@
       "version": "3.24.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
       "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/node": "^25.9.1",
     "copyfiles": "^2.4.1",
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
     "compilerOptions": {
       "target": "ES2020",
-      "module": "esnext",
-      "moduleResolution": "node",
+      "module": "NodeNext",
+      "moduleResolution": "nodenext",
       "esModuleInterop": true,
       "outDir": "./dist",
       "rootDir": ".",
-      "ignoreDeprecations": "6.0",
       "strict": true,
       "declaration": true,
       "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
     "compilerOptions": {
       "target": "ES2020",
-      "module": "ESNext",
+      "module": "esnext",
       "moduleResolution": "node",
       "esModuleInterop": true,
       "outDir": "./dist",
       "rootDir": ".",
+      "ignoreDeprecations": "6.0",
       "strict": true,
       "declaration": true,
       "skipLibCheck": true,
-      "allowSyntheticDefaultImports": true
+      "allowSyntheticDefaultImports": true,
+      "types": ["node"]
     },
     "include": [
       "./**/*.ts"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "isolatedModules": true
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This pull request introduces a comprehensive test suite for the core data search and utility functions, refactors the search logic to support fuzzy matching and better pagination, and adds full TypeScript/Jest support for ESM modules. The changes improve both the reliability of the codebase and the quality of search results.

**Testing infrastructure and configuration:**

* Added a complete test suite in `index.test.ts` covering all main exported functions, including `fuzzyScore`, `searchFile`, `fileExists`, `getFileDetails`, and `listDataFiles`. The tests cover exact and fuzzy matching, pagination, file existence, and metadata extraction.
* Added Jest configuration for TypeScript ESM (`jest.config.cjs`) and a separate test TypeScript config (`tsconfig.test.json`) to ensure proper test compilation and execution. [[1]](diffhunk://#diff-17d090b5ad85e342cd83ee805ef525ea9307d4be9588ac4a7db60042ef6c6d14R1-R12) [[2]](diffhunk://#diff-e4fb77850197aa340b1f8f426bb0d445c854e20f0a3dd184050ed555fae92713R1-R13)
* Included `@types/node` in dev dependencies for improved type safety in tests.
* Updated the CI workflow to run tests after building the project. (.github/workflows/ci.yml)

**Search and matching improvements:**

* Introduced a new `fuzzyScore` function to score matches between search terms and file lines, supporting exact, token-based, and subsequence (fuzzy/typo) matches, and made search case-insensitive.
* Refactored `searchFile` to use the new `fuzzyScore` for ranking results, sort results by score (best matches first), and replace all spaces with underscores in the search term for better matching. Also improved error handling for missing files. [[1]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L105-R145) [[2]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L125-R171)

**API and export changes:**

* Exported `fuzzyScore`, `searchFile`, `fileExists`, `getFileDetails`, and `listDataFiles` for use in tests and other modules. [[1]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L178-R211) [[2]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L188-R221) [[3]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L231-R264)
* Prevented the main server from starting during test runs by checking for the Jest environment.