### PR TITLE
feat: add Grand Exchange price lookup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ This server implements the following tools:
 18. `get_file_details` - Get details about a file in the data directory
 19. `list_data_files` - List available data files in the data directory
 
+### Grand Exchange Prices
+20. `search_ge_items` - Search for Grand Exchange tradeable items by name. Returns item IDs, names, buy limits, and alch values
+21. `get_ge_latest` - Get the latest Grand Exchange high and low prices for a specific item by its ID
+22. `get_ge_timeseries` - Get historical time-series price data for an item at a given interval (5m, 1h, 6h, 24h). Returns up to 365 data points
+
+### Player Lookup
+23. `lookup_player` - Look up an OSRS player's stats (skills, bosses, clue scrolls, and activities) from the official hiscores
+
 ## Installation
 
 ### Installing via Smithery
@@ -132,6 +140,41 @@ const items = await callTool("search_objtypes", {
 ```javascript
 // Get a list of all data files
 const files = await callTool("list_data_files", {});
+```
+
+### Search Grand Exchange Items
+```javascript
+// Search for tradeable items by name
+const items = await callTool("search_ge_items", { 
+  query: "dragon scimitar",
+  page: 1,
+  pageSize: 10
+});
+```
+
+### Get Latest GE Prices
+```javascript
+// Get the latest high/low prices for an item
+const prices = await callTool("get_ge_latest", { 
+  itemId: 2 // Cannonball
+});
+```
+
+### Get GE Price History
+```javascript
+// Get time-series price data for an item
+const history = await callTool("get_ge_timeseries", { 
+  itemId: 2,
+  timestep: "1h"
+});
+```
+
+### Look Up a Player
+```javascript
+// Look up an OSRS player's stats
+const stats = await callTool("lookup_player", { 
+  playerName: "Zezima"
+});
 ```
 
 ## Development

--- a/ge-prices.test.ts
+++ b/ge-prices.test.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals';
+import {
+  pricesApiClient,
+  searchItems,
+  getLatest,
+  getTimeSeries,
+  clearCache,
+  GeLatestSchema,
+  SearchGeItemsSchema,
+  GeTimeSeriesSchema,
+} from './ge-prices.js';
+
+const mockItems = [
+  { id: 4151, name: 'Abyssal whip', members: true, limit: 10, highalch: 180000, lowalch: 120000, value: 150000, icon: 'abyssal_whip.png', examine: 'A weapon from the abyss.' },
+  { id: 2, name: 'Cannonball', members: true, limit: 3000, highalch: 12, lowalch: 8, value: 10, icon: 'cannonball.png', examine: 'Ammo for the Dwarf Cannon.' },
+  { id: 3, name: 'Abyssal dagger', members: true, limit: 10, highalch: 30000, lowalch: 20000, value: 25000, icon: 'abyssal_dagger.png', examine: 'A dagger from the abyss.' },
+  { id: 4, name: 'Dragon scimitar', members: true, limit: 10, highalch: 60000, lowalch: 40000, value: 50000, icon: 'dragon_scimitar.png', examine: 'A vicious curved sword.' },
+  { id: 5, name: 'Abyssal dagger (p)', members: true, limit: 10, highalch: 30000, lowalch: 20000, value: 25000, icon: 'abyssal_dagger_p.png', examine: 'A dagger from the abyss, poisoned.' },
+];
+
+const mockLatest = { data: { '4151': { high: 1850000, highTime: 1749200000, low: 1820000, lowTime: 1749200000 } } };
+const mockTimeSeries = { data: [{ high: 1850000, highTime: 1749200000, low: 1820000, lowTime: 1749200000 }], timestamp: 1615733400 };
+
+let mockedGet: jest.SpyInstance;
+
+beforeEach(() => {
+  clearCache();
+  mockedGet = jest.spyOn(pricesApiClient, 'get').mockImplementation(async (url: string) => {
+    if (url === '/mapping') return { data: mockItems };
+    if (url === '/latest') return { data: mockLatest };
+    if (url === '/timeseries') return { data: mockTimeSeries };
+    return { data: {} };
+  });
+});
+
+afterEach(() => {
+  mockedGet.mockRestore();
+});
+
+describe('searchItems', () => {
+  it('finds items matching the query by substring', async () => {
+    const result = await searchItems('abyssal');
+    expect(result.results.length).toBe(3);
+    const names = result.results.map(r => r.name);
+    expect(names).toContain('Abyssal whip');
+    expect(names).toContain('Abyssal dagger');
+    expect(names).toContain('Abyssal dagger (p)');
+    expect(names.length).toBe(3);
+  });
+
+  it('is case-insensitive', async () => {
+    const upper = await searchItems('ABYSSAL');
+    const lower = await searchItems('abyssal');
+    expect(upper.results.length).toBe(lower.results.length);
+    expect(upper.results[0].id).toBe(lower.results[0].id);
+  });
+
+  it('returns exact match first', async () => {
+    const result = await searchItems('Dragon scimitar');
+    expect(result.results[0].name).toBe('Dragon scimitar');
+  });
+
+  it('sorts results by score descending, then alphabetically', async () => {
+    const result = await searchItems('abyssal');
+    const names = result.results.map(r => r.name);
+    expect(names).toEqual(['Abyssal dagger', 'Abyssal dagger (p)', 'Abyssal whip']);
+  });
+
+  it('paginates results correctly', async () => {
+    const page1 = await searchItems('abyssal', 1, 2);
+    expect(page1.results.length).toBe(2);
+    expect(page1.pagination.page).toBe(1);
+    expect(page1.pagination.totalResults).toBe(3);
+    expect(page1.pagination.hasNextPage).toBe(true);
+
+    const page2 = await searchItems('abyssal', 2, 2);
+    expect(page2.results.length).toBe(1);
+    expect(page2.pagination.page).toBe(2);
+    expect(page2.pagination.hasPreviousPage).toBe(true);
+    expect(page2.pagination.hasNextPage).toBe(false);
+  });
+
+  it('returns empty results for a query with no matches', async () => {
+    const result = await searchItems('zzz_nonexistent');
+    expect(result.results).toHaveLength(0);
+    expect(result.pagination.totalResults).toBe(0);
+  });
+
+  it('caches the mapping across multiple calls', async () => {
+    mockedGet.mockClear();
+    await searchItems('abyssal');
+    await searchItems('dragon');
+    await searchItems('cannon');
+    const mappingCalls = mockedGet.mock.calls.filter(([url]: [string]) => url === '/mapping');
+    expect(mappingCalls).toHaveLength(1);
+  });
+
+  it('returns item metadata fields', async () => {
+    const result = await searchItems('cannonball');
+    expect(result.results[0]).toMatchObject({
+      id: 2,
+      name: 'Cannonball',
+      members: true,
+      limit: 3000,
+      highalch: 12,
+      lowalch: 8,
+      value: 10,
+    });
+  });
+});
+
+describe('getLatest', () => {
+  it('requests /latest with the given item ID', async () => {
+    await getLatest(4151);
+    expect(mockedGet).toHaveBeenCalledWith('/latest', { params: { id: 4151 } });
+  });
+
+  it('returns price data for a known item', async () => {
+    const result = await getLatest(4151);
+    expect(result).toEqual(mockLatest);
+    expect(result.data['4151'].high).toBe(1850000);
+    expect(result.data['4151'].low).toBe(1820000);
+    expect(result.data['4151']).toHaveProperty('highTime');
+    expect(result.data['4151']).toHaveProperty('lowTime');
+  });
+});
+
+describe('getTimeSeries', () => {
+  it('requests /timeseries with id and timestep', async () => {
+    await getTimeSeries(4151, '5m');
+    expect(mockedGet).toHaveBeenCalledWith('/timeseries', { params: { id: 4151, timestep: '5m' } });
+  });
+
+  it('returns time series data array', async () => {
+    const result = await getTimeSeries(4151, '5m');
+    expect(result).toEqual(mockTimeSeries);
+    expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data[0]).toHaveProperty('high');
+    expect(result.data[0]).toHaveProperty('low');
+  });
+});
+
+describe('User-Agent header', () => {
+  it('includes a custom User-Agent on the axios client', () => {
+    const headers = pricesApiClient.defaults.headers;
+    const userAgent = headers['User-Agent'] || (headers.common && headers.common['User-Agent']);
+    expect(userAgent).toBeTruthy();
+    expect(userAgent).toContain('mcp-osrs');
+  });
+});
+
+describe('Zod schemas', () => {
+  it('GeLatestSchema accepts valid input', () => {
+    const result = GeLatestSchema.parse({ itemId: 4151 });
+    expect(result.itemId).toBe(4151);
+  });
+
+  it('GeLatestSchema rejects non-positive itemId', () => {
+    expect(() => GeLatestSchema.parse({ itemId: -1 })).toThrow();
+    expect(() => GeLatestSchema.parse({ itemId: 0 })).toThrow();
+  });
+
+  it('SearchGeItemsSchema applies defaults', () => {
+    const result = SearchGeItemsSchema.parse({ query: 'whip' });
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+  });
+
+  it('SearchGeItemsSchema rejects empty query', () => {
+    expect(() => SearchGeItemsSchema.parse({ query: '' })).toThrow();
+  });
+
+  it('GeTimeSeriesSchema accepts valid timesteps', () => {
+    for (const ts of ['5m', '1h', '6h', '24h']) {
+      expect(() => GeTimeSeriesSchema.parse({ itemId: 4151, timestep: ts })).not.toThrow();
+    }
+  });
+
+  it('GeTimeSeriesSchema rejects invalid timestep', () => {
+    expect(() => GeTimeSeriesSchema.parse({ itemId: 4151, timestep: '1d' })).toThrow();
+  });
+});

--- a/ge-prices.ts
+++ b/ge-prices.ts
@@ -1,0 +1,109 @@
+import axios from 'axios';
+import { z } from 'zod';
+
+const USER_AGENT = 'mcp-osrs - https://github.com/jayarrowz/mcp-osrs';
+
+export const pricesApiClient = axios.create({
+  baseURL: 'https://prices.runescape.wiki/api/v1/osrs',
+  headers: { 'User-Agent': USER_AGENT },
+});
+
+export interface ItemMapping {
+  id: number;
+  name: string;
+  examine?: string;
+  members: boolean;
+  lowalch?: number;
+  limit?: number;
+  value: number;
+  highalch?: number;
+  icon: string;
+}
+
+let mappingCache: ItemMapping[] | null = null;
+
+export function clearCache(): void {
+  mappingCache = null;
+}
+
+async function ensureMapping(): Promise<ItemMapping[]> {
+  if (mappingCache) return mappingCache;
+  const response = await pricesApiClient.get('/mapping');
+  mappingCache = response.data;
+  return mappingCache!;
+}
+
+function scoreItem(item: ItemMapping, query: string): number {
+  const name = item.name.toLowerCase();
+  const q = query.toLowerCase();
+  if (name === q) return 100;
+  if (name.startsWith(q)) return 80;
+  if (name.includes(q)) return 60;
+  return 0;
+}
+
+export async function searchItems(
+  query: string,
+  page: number = 1,
+  pageSize: number = 20,
+): Promise<{
+  results: ItemMapping[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalResults: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+}> {
+  const items = await ensureMapping();
+  const scored = items
+    .map(item => ({ item, score: scoreItem(item, query) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score || a.item.name.localeCompare(b.item.name));
+
+  const totalResults = scored.length;
+  const totalPages = Math.ceil(totalResults / pageSize);
+  const startIndex = (page - 1) * pageSize;
+  const paginatedResults = scored.slice(startIndex, startIndex + pageSize).map(s => s.item);
+
+  return {
+    results: paginatedResults,
+    pagination: {
+      page,
+      pageSize,
+      totalResults,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    },
+  };
+}
+
+export async function getLatest(itemId: number): Promise<any> {
+  const response = await pricesApiClient.get('/latest', { params: { id: itemId } });
+  return response.data;
+}
+
+export async function getTimeSeries(itemId: number, timestep: string): Promise<any> {
+  const response = await pricesApiClient.get('/timeseries', { params: { id: itemId, timestep } });
+  return response.data;
+}
+
+export const GeLatestSchema = z.object({
+  itemId: z.number().int().positive().describe("The item ID to get the latest price for"),
+});
+
+export const SearchGeItemsSchema = z.object({
+  query: z.string().min(1).describe("Search term to find items by name"),
+  page: z.number().int().min(1).optional().default(1).describe("Page number for pagination"),
+  // Default pageSize of 20 reduces the need for paginated round-trips on broad queries
+  // without being wasteful for precise queries that return few results.
+  pageSize: z.number().int().min(1).max(100).optional().default(20).describe("Number of results per page"),
+});
+
+export const GeTimeSeriesSchema = z.object({
+  itemId: z.number().int().positive().describe("The item ID to get the time series for"),
+  timestep: z.enum(['5m', '1h', '6h', '24h']).describe("Time interval between data points"),
+});

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,8 @@ import path from 'path';
 import readline from 'readline';
 import { fileURLToPath } from 'url';
 import { getStats, getStatsByGamemode } from 'osrs-json-hiscores';
+import { searchItems, getLatest, getTimeSeries } from './ge-prices.js';
+import { SearchGeItemsSchema, GeLatestSchema, GeTimeSeriesSchema } from './ge-prices.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -379,6 +381,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 description: "Look up an OSRS player's stats (skills, bosses, clue scrolls, and activities) from the official hiscores.",
                 inputSchema: convertZodToJsonSchema(LookupPlayerSchema),
             },
+            {
+                name: "search_ge_items",
+                description: "Search for Grand Exchange tradeable items by name. Uses an exact/prefix/substring match. Returns item IDs, names, buy limits, and alch values.",
+                inputSchema: convertZodToJsonSchema(SearchGeItemsSchema),
+            },
+            {
+                name: "get_ge_latest",
+                description: "Get the latest Grand Exchange high and low prices for a specific item by its ID.",
+                inputSchema: convertZodToJsonSchema(GeLatestSchema),
+            },
+            {
+                name: "get_ge_timeseries",
+                description: "Get historical time-series price data for an item at a given interval (5m, 1h, 6h, 24h). Returns up to 365 data points.",
+                inputSchema: convertZodToJsonSchema(GeTimeSeriesSchema),
+            },
         ]
     };
 });
@@ -490,6 +507,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     playerStats = await getStats(playerName);
                 }
                 return responseToString(playerStats);
+
+            case "search_ge_items": {
+                const { query, page: gePage, pageSize: gePageSize } = SearchGeItemsSchema.parse(args);
+                const geResults = await searchItems(query, gePage, gePageSize);
+                return responseToString(geResults);
+            }
+
+            case "get_ge_latest": {
+                const { itemId } = GeLatestSchema.parse(args);
+                const latest = await getLatest(itemId);
+                return responseToString(latest);
+            }
+
+            case "get_ge_timeseries": {
+                const { itemId: tsItemId, timestep } = GeTimeSeriesSchema.parse(args);
+                const series = await getTimeSeries(tsItemId, timestep);
+                return responseToString(series);
+            }
 
             default:
                 throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
Still messing with this, and found these GE endpoints useful as well for what I'm doing. I pulled the new functionality to its own file to prevent bloat on the index file. 

I also added some documentation to the README since I realized I forgot to do that on the last pass through here. 

## What This PR Does

Adds three new MCP tools for OSRS Grand Exchange data:

- **search_ge_items** — search tradeable items by name with exact/prefix/substring matching and paginated results (default pageSize=20 to reduce LLM round-trips)
- **get_ge_latest** — fetch latest high/low prices for a specific item by ID
- **get_ge_timeseries** — fetch historical price candles at 5m, 1h, 6h, or 24h intervals (up to 365 data points)

All tools consume the OSRS Wiki prices API (`prices.runescape.wiki`) and include unit tests.